### PR TITLE
Optionally get the solution path from the project file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ case, that means that when you open a view with the `source.cs` base scope, inst
 
 Configure OmniSharp by running `Preferences: LSP-OmniSharp Settings` from the Command Palette.
 
+## Project Setting
+
+The server will automatically find the the solution file from the folder you have opened in Sublime. If you have multiple solutions, or your solution is in another folder, you have to specify the solution file you wish to use in a `sublime-project`. 
+
+1. Go to `File -> Open` and select the folder with your solution in it.
+
+2. Go to `Project -> Save Project As` and save a `YOURPROJECTNAME.sublime-project` in desired location.
+
+3. Open your `YOURPROJECTNAME.sublime-project` file that should now appear in the sidebar on the left
+
+4. Enter the location to the `*.sln` file like below
+
+```
+{
+    "folders":
+    [
+        {
+            "follow_symlinks": true,
+            "path": "."
+        }
+    ],
+    "solution_file": "./testconsoleprj.sln"
+}
+```
+
+Once the `YOURPROJECT.sublime-project` is set up and saved, the next time you open this project in sublime, OmniSharp will use the specified solution.
+
 ## Capabilities
 
 OmniSharp can do a lot of cool things, like

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The server will automatically find the the solution file from the folder you hav
 
 4. Enter the location to the `*.sln` file like below
 
+### Example sublime-project file
+
 ```
 {
     "folders":

--- a/plugin.py
+++ b/plugin.py
@@ -67,6 +67,21 @@ class OmniSharp(AbstractPlugin):
             return os.path.join(cls.basedir(), "omnisharp", "OmniSharp.exe")
 
     @classmethod
+    def get_solution_arguments(cls) -> List[str]:
+        view = sublime.active_window().active_view()
+        project_file = view.window().project_file_name()
+
+        if project_file is not None:
+            data = view.window().project_data()
+            if 'solution_file' in data:
+                project_dir = os.path.dirname(project_file)
+                solution_file_name = data['solution_file']
+                solution_file_path = os.path.join(project_dir, solution_file_name)
+                return ["-s", os.path.abspath(solution_file_path)]
+
+        return []
+
+    @classmethod
     def get_command(cls) -> List[str]:
         settings = cls.get_settings()
         cmd = settings.get("command")
@@ -76,7 +91,7 @@ class OmniSharp(AbstractPlugin):
 
     @classmethod
     def get_windows_command(cls) -> List[str]:
-        return [cls.binary_path(), "--languageserver"]
+        return [cls.binary_path(), "--languageserver"] + cls.get_solution_arguments()
 
     @classmethod
     def get_osx_command(cls) -> List[str]:


### PR DESCRIPTION
There's a legacy [OmniSharp package](https://github.com/OmniSharp/omnisharp-sublime) for Sublime Text 3 that has a very handy feature: It allows you to specify a solution file to use with OmniSharp in your sublime-project. 

That package is causing me some issues with Sublime Text 4, so I'm trying to use this one as a replacement, but it's lacking that feature.

This pull request will add this feature here. I used the same syntax as the other package, so they are compatible.

_Note: I only tested this on Windows and MacOS, as I don't have any Linux machine at hand right now._