### PR TITLE
Use the latest Omnisharp server on Linux and macOS without mono

### DIFF
--- a/LSP-OmniSharp.sublime-settings
+++ b/LSP-OmniSharp.sublime-settings
@@ -73,5 +73,7 @@
         "omnisharp.useEditorFormattingSettings": true,
         // Enable/disable default Razor formatter.
         "razor.format.enable": true,
+        // Default version of the omnisharp server
+        "omnisharp.version": "1.39.11"
     }
 }

--- a/LSP-OmniSharp.sublime-settings
+++ b/LSP-OmniSharp.sublime-settings
@@ -73,7 +73,7 @@
         "omnisharp.useEditorFormattingSettings": true,
         // Enable/disable default Razor formatter.
         "razor.format.enable": true,
-        // Default version of the omnisharp server
+        // Default version of the omnisharp server, used when downloading the server automatically
         "omnisharp.version": "1.39.11"
     }
 }

--- a/plugin.py
+++ b/plugin.py
@@ -35,7 +35,8 @@ def _omnisharp_archive() -> str:
     try:
         return OMNISHARP_ARCHIVE[platform][arch]
     except KeyError:
-        raise RuntimeError("{}-{} is not a supported combination.".format(platform, arch))
+        raise RuntimeError(
+            "{}-{} is not currently a supported platform for LSP-OmniSharp.".format(platform, arch))
 
 
 class OmniSharp(AbstractPlugin):
@@ -72,6 +73,11 @@ class OmniSharp(AbstractPlugin):
 
     @classmethod
     def binary_path(cls) -> str:
+        settings = cls.get_settings().get("settings")
+        server_path = settings.get("omnisharp.serverPath")
+        if server_path is not None:
+            return server_path
+
         platform = sublime.platform()
         if platform == "windows":
             return os.path.join(cls.basedir(), "OmniSharp.exe")
@@ -93,14 +99,6 @@ class OmniSharp(AbstractPlugin):
     @classmethod
     def get_osx_command(cls) -> List[str]:
         return cls.get_linux_command()
-
-    @classmethod
-    def mono_bin_path(cls) -> str:
-        return os.path.join(cls.basedir(), "bin", "mono")
-
-    @classmethod
-    def mono_config_path(cls) -> str:
-        return os.path.join(cls.basedir(), "etc", "config")
 
     @classmethod
     def get_linux_command(cls) -> List[str]:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -136,6 +136,11 @@
                       "default": "1.39.11",
                       "description": "Specify the OmniSharp-roslyn release version",
                       "type": "string"
+                    },
+                    "omnisharp.serverPath": {
+                      "default": null,
+                      "description": "A path to a user installed omnisharp binary. Used instead of an automatically downloaded release.",
+                      "type": "string"
                     }
                   }
                 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -131,6 +131,11 @@
                       "default": true,
                       "description": "Enable/disable default Razor formatter.",
                       "type": "boolean"
+                    },
+                    "omnisharp.version": {
+                      "default": "1.39.11",
+                      "description": "Specify the OmniSharp-roslyn release version",
+                      "type": "string"
                     }
                   }
                 }


### PR DESCRIPTION
Also allows the configuration of the omnisharp server version using the package settings.

*I haven't tested this on a macOS system yet* :grimacing: 

This is very much a "works for me on my laptop" situation and as such I'm ready to iterate and get things into a shape you're willing to accept. :+1: 