### PR TITLE
Fix unix language server binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a helper package that automatically installs and updates
 To use this package, you must have:
 
 - The [LSP](https://packagecontrol.io/packages/LSP) package.
-- The [.NET SDK](https://dotnet.microsoft.com/download). (The "Core" version **does not work on macOS**.)
+- The [.NET SDK 6 or higher](https://dotnet.microsoft.com/download).
 - (Optional but recommended) Install the [LSP-file-watcher-chokidar](https://github.com/sublimelsp/LSP-file-watcher-chokidar) via Package Control to enable functionality to notify the server about new files.
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -73,7 +73,7 @@ class OmniSharp(AbstractPlugin):
         if sublime.platform() == "windows":
             return os.path.join(cls.basedir(), "OmniSharp.exe")
         else:
-            return os.path.join(cls.basedir(), "omnisharp", "OmniSharp.exe")
+            return os.path.join(cls.basedir(), "OmniSharp")
 
     @classmethod
     def get_command(cls) -> list[str]:
@@ -81,32 +81,7 @@ class OmniSharp(AbstractPlugin):
         cmd = settings.get("command")
         if isinstance(cmd, list):
             return cmd
-        return getattr(cls, "get_{}_command".format(sublime.platform()))()
-
-    @classmethod
-    def get_windows_command(cls) -> list[str]:
         return [cls.binary_path(), "--languageserver"]
-
-    @classmethod
-    def get_osx_command(cls) -> list[str]:
-        return cls.get_linux_command()
-
-    @classmethod
-    def mono_bin_path(cls) -> str:
-        return os.path.join(cls.basedir(), "bin", "mono")
-
-    @classmethod
-    def mono_config_path(cls) -> str:
-        return os.path.join(cls.basedir(), "etc", "config")
-
-    @classmethod
-    def get_linux_command(cls) -> list[str]:
-        return [
-            cls.mono_bin_path(),
-            "--assembly-loader=strict",
-            "--config",
-            cls.mono_config_path()
-        ] + cls.get_windows_command()
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:
@@ -129,7 +104,7 @@ class OmniSharp(AbstractPlugin):
                 f.extractall(cls.basedir())
             os.unlink(zipfile)
             if sublime.platform() != "windows":
-                os.chmod(cls.mono_bin_path(), 0o744)
+                os.chmod(cls.binary_path(), 0o744)
             with open(os.path.join(cls.basedir(), "VERSION"), "w") as fp:
                 fp.write(version)
         except Exception:


### PR DESCRIPTION
This PR fixes OmniSharp binary path references on Linux and MacOS.

Note: It replaces `os.path` functions by more modern `pathlib`.