### PR TITLE
Update method for printing message to the status bar

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -163,9 +163,9 @@ class OmniSharp(AbstractPlugin):
         if session:
             message = fmt.format(*args)
             if sticky:
-                session.set_window_status_async(self.name(), message)
+                session.set_config_status_async(message)
             else:
-                session.erase_window_status_async(self.name())
+                session.set_config_status_async("")
                 session.window.status_message(message)
 
     def m_o__msbuildprojectdiagnostics(self, params: Any) -> None:


### PR DESCRIPTION
I'd like to deprecate the `Session.set_window_status_async` method in LSP, because there is also the newer `Session.set_config_status_async` which does basically the same thing.

The only change from this PR should be that the "Compiled \<filename>" messages will be shown in brackets directly after the server name in the status bar.