### PR TITLE
make IsWow64Process2 compatible with latest python runtimes

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -43,6 +43,8 @@ MACHINE_NAMES: dict[ImageFileMachine, str] = {
 def get_host_arch() -> str:
     if sublime.platform() == "windows":
         kernel32 = ctypes.windll.kernel32
+        c_ushort_p = ctypes.POINTER(ctypes.c_ushort)
+        kernel32.IsWow64Process2.argtypes = (ctypes.c_void_p, c_ushort_p, c_ushort_p)
         process_machine = ctypes.c_ushort(0)
         native_machine  = ctypes.c_ushort(0)
         success = kernel32.IsWow64Process2(


### PR DESCRIPTION
Fix compatibility with latest python runtimes when calling `IsWow64Process2`.
Solution from https://github.com/sublimehq/sublime_text/issues/6872#issuecomment-4234702621